### PR TITLE
Adds URLReplacement functionality

### DIFF
--- a/mediasms.go
+++ b/mediasms.go
@@ -136,5 +136,6 @@ func ReplaceMessageBodyURLs(messageBody string, allURLs []string) string {
 	for i := range allURLs {
 		messageBody = strings.Replace(messageBody, allURLs[i], urlReplacements[i], 1)
 	}
+
 	return messageBody
 }

--- a/mediasms.go
+++ b/mediasms.go
@@ -128,3 +128,13 @@ func (c Client) GetStatus(messageID string) (models.APIResponse, error) {
 
 	return response, nil
 }
+
+// ReplaceMessageBodyURLs removes urls and replaces them with mediasms acceptable values
+func ReplaceMessageBodyURLs(messageBody string, allURLs []string) string {
+	urlReplacements := []string{"{URL}", "{URL2}", "{URL3}", "{URL4}"}
+
+	for i := range allURLs {
+		messageBody = strings.Replace(messageBody, allURLs[i], urlReplacements[i], 1)
+	}
+	return messageBody
+}

--- a/mediasms_test.go
+++ b/mediasms_test.go
@@ -1,0 +1,15 @@
+package mediasms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceMessageBodyURLs(t *testing.T) {
+	messageBody := "http://google.com to https://github.com to http://stackoverflow.com and http://google.com"
+	allURLs := []string{"http://google.com", "https://github.com", "http://stackoverflow.com", "http://google.com"}
+
+	newMessageBody := ReplaceMessageBodyURLs(messageBody, allURLs)
+	assert.Equal(t, "{URL} to {URL2} to {URL3} and {URL4}", newMessageBody, "they should be equal")
+}


### PR DESCRIPTION
## Description:

Replacing URLs in message body has been moved from `sms-api` to this library. 

Usage:
```
messageBody := "http://google.com test message http://stackoverflow.com"
allURLs := []string{"http://google.com", "http://stackoverflow.com"}

request.SMSText = mediasms.ReplaceMessageBodyURLs(contactMessage.Body, allURLs)
```

Result
`"{URL} test message {URL2}"`

## Added

- URL Replacement function
- test

## References:

https://comvex.myjetbrains.com/youtrack/agiles/107-0/108-196?issue=DGM2-4103