### PR TITLE
fix: Status code for Rakuten Partial Delivered

### DIFF
--- a/translations/translations.go
+++ b/translations/translations.go
@@ -12,7 +12,7 @@ var TranslationMap = map[int]string{
 	5:  models.StatusFailedInvalidPhoneNumber,
 	7:  models.StatusFailedAuOutOfServiceArea,
 	8:  models.StatusFailedAuNwFailure,
-	9:  models.StatusFailedAuNwFailure,
+	9:  models.StatusFailedAuNwOther,
 	10: models.StatusFailedAuNotPaid,
 	11: models.StatusProcessing,
 	12: models.StatusFailedAuOther,
@@ -45,6 +45,6 @@ var TranslationMap = map[int]string{
 	39: models.StatusApprovalPending,
 	40: models.StatusFailedRakutenOther,
 	41: models.StatusFailedRakutenNwMalfunction,
-	42: models.StatusFailedDocomoPartialReception,
+	42: models.StatusFailedRakutenPartialReception,
 	43: models.StatusFailedRakutenOutOfServiceArea,
 }


### PR DESCRIPTION
## Description:
`models.StatusFailedDocomoPartialReception` was duplicated as 32 and 42
`models.StatusFailedAuNwFailure` was duplicated as 8 and 9

Related PR: [proxy:backend-app](https://github.com/comvex-jp/digima-backend-app/pull/4021)

## References:

[DGM2-8210](https://comvex.myjetbrains.com/youtrack/issue/DGM2-8210)

## Acceptance Criteria:

*Proxy accepts partial delivered statuses as `PartialDelivered` Event
